### PR TITLE
Bugfix: Fix GpioPin __call__ method.

### DIFF
--- a/fbsd_gpio/__init__.py
+++ b/fbsd_gpio/__init__.py
@@ -272,9 +272,11 @@ class GpioPin(object):
                 """Set or get the value of the pin
                 :param value: If set, set the value of the pin
                 """
-                if value:
+                if value is None:
+                        return self._controller.pin_get(self._num)
+                else:
                         self._controller.pin_set(self._num, value)
-                return self._controller.pin_get(self._num)
+                
 
         @property
         def name(self):


### PR DESCRIPTION
The GpioPin.__call__ method tests value for boolean truth when compute
it's behavior, setting or getting the pin's value. This means that it
cannot set a pin to 0 or any other value that would evaluate to false
in a boolean context.